### PR TITLE
Fix error list output for `cli` format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default (schema, data, errors, options = {}) => {
   });
 
   if (format === 'cli') {
-    return customErrors.map(customErrorToText).join();
+    return customErrors.map(customErrorToText).join('\n\n');
   } else {
     return customErrors.map(customErrorToStructure);
   }


### PR DESCRIPTION
Currently error messages are joining by a comma. 
![image](https://user-images.githubusercontent.com/270491/40235912-68aefc98-5ab4-11e8-8cf4-79b6adc1ef1d.png)

With this fix messages are joining by 2 new lines as expected.
![image](https://user-images.githubusercontent.com/270491/40235991-b9daba08-5ab4-11e8-9742-208e66a6cf41.png)

