### PR TITLE
fix: do not remove errors with no children

### DIFF
--- a/src/__tests__/__snapshots__/helpers.js.snap
+++ b/src/__tests__/__snapshots__/helpers.js.snap
@@ -56,6 +56,32 @@ Object {
 }
 `;
 
+exports[`filterRedundantErrors should not remove anyOf errors if there are no children 1`] = `
+Object {
+  "children": Object {
+    "/object": Object {
+      "children": Object {
+        "/type": Object {
+          "children": Object {},
+          "errors": Array [
+            Object {
+              "keyword": "type",
+            },
+            Object {
+              "keyword": "type",
+            },
+            Object {
+              "keyword": "anyOf",
+            },
+          ],
+        },
+      },
+      "errors": Array [],
+    },
+  },
+}
+`;
+
 exports[`filterRedundantErrors should prioritize required 1`] = `
 Object {
   "children": Object {

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -150,4 +150,55 @@ describe('filterRedundantErrors', () => {
     filterRedundantErrors(tree);
     expect(tree).toMatchSnapshot();
   });
+
+  it('should not remove anyOf errors if there are no children', async () => {
+    const tree = {
+      children: {
+        '/object': {
+          children: {
+            '/type': {
+              children: {},
+              errors: [
+                {
+                  keyword: 'type',
+                },
+                {
+                  keyword: 'type',
+                },
+                {
+                  keyword: 'anyOf',
+                },
+              ],
+            },
+          },
+          errors: [],
+        },
+      },
+    };
+
+    filterRedundantErrors(tree);
+    expect(tree).toEqual({
+      children: {
+        '/object': {
+          children: {
+            '/type': {
+              children: {},
+              errors: [
+                {
+                  keyword: 'type',
+                },
+                {
+                  keyword: 'type',
+                },
+                {
+                  keyword: 'anyOf',
+                },
+              ],
+            },
+          },
+          errors: [],
+        },
+      },
+    });
+  });
 });

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -177,28 +177,6 @@ describe('filterRedundantErrors', () => {
     };
 
     filterRedundantErrors(tree);
-    expect(tree).toEqual({
-      children: {
-        '/object': {
-          children: {
-            '/type': {
-              children: {},
-              errors: [
-                {
-                  keyword: 'type',
-                },
-                {
-                  keyword: 'type',
-                },
-                {
-                  keyword: 'anyOf',
-                },
-              ],
-            },
-          },
-          errors: [],
-        },
-      },
-    });
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -52,10 +52,14 @@ export function filterRedundantErrors(root, parent, key) {
   /**
    * If there is an `anyOf` error that means we have more meaningful errors
    * inside children. So we will just remove all errors from this level.
+   *
+   * If there are no children, then we don't delete the errors since we should
+   * have at least one error to report.
    */
-  // TODO: Need to check children too. There might be no children :(
   if (getErrors(root).some(isAnyOfError)) {
-    delete root.errors;
+    if (Object.keys(root.children).length > 0) {
+      delete root.errors;
+    }
   }
 
   /**


### PR DESCRIPTION
I encountered an issue where ajv errors like this:

```js
[
  {
    keyword: 'type',
    dataPath: '/object/type',
    schemaPath: '#/definitions/type/anyOf/0/type',
    params: [Object],
    message: 'should be string'
  },
  {
    keyword: 'type',
    dataPath: '/object/type',
    schemaPath: '#/definitions/type/anyOf/1/type',
    params: [Object],
    message: 'should be array'
  },
  {
    keyword: 'anyOf',
    dataPath: '/object/type',
    schemaPath: '#/definitions/type/anyOf',
    params: {},
    message: 'should match some schema in anyOf'
  }
]
```

... would return a completely empty error message, since `filterRedundantErrors` would remove all the errors.

This PR makes sure that `filterRedundantErrors` doesn't remove the errors if the node doesn't have any children.