### PR TITLE
Handle JSON pointer escape notation, fixes #23

### DIFF
--- a/src/json/__fixtures__/scenario-5.json
+++ b/src/json/__fixtures__/scenario-5.json
@@ -1,0 +1,10 @@
+{
+  "foo": {
+    "/some/path": {
+      "value": 1
+    },
+    "~some~path": {
+      "value": 2
+    }
+  }
+}

--- a/src/json/__tests__/__snapshots__/index.js.snap
+++ b/src/json/__tests__/__snapshots__/index.js.snap
@@ -169,3 +169,46 @@ Object {
   "value": "foo",
 }
 `;
+
+exports[`JSON can work with unescaped JSON pointers with ~0 1`] = `
+Object {
+  "loc": Object {
+    "end": Object {
+      "column": 17,
+      "line": 7,
+      "offset": 93,
+    },
+    "source": null,
+    "start": Object {
+      "column": 16,
+      "line": 7,
+      "offset": 92,
+    },
+  },
+  "raw": "2",
+  "type": "Literal",
+  "value": 2,
+}
+`;
+
+exports[`JSON can work with unescaped JSON pointers with ~1 1`] = `
+Object {
+  "loc": Object {
+    "end": Object {
+      "column": 17,
+      "line": 4,
+      "offset": 49,
+    },
+    "source": null,
+    "start": Object {
+      "column": 16,
+      "line": 4,
+      "offset": 48,
+    },
+  },
+  "raw": "1",
+  "type": "Literal",
+  "value": 1,
+}
+`;
+

--- a/src/json/__tests__/index.js
+++ b/src/json/__tests__/index.js
@@ -42,4 +42,20 @@ describe('JSON', () => {
     const jsonAst = parse(rawJson, { loc: true });
     expect(getDecoratedDataPath(jsonAst, '/arr/4')).toMatchSnapshot();
   });
+
+  it('can work with unescaped JSON pointers with ~1', async () => {
+    const rawJson = await loadScenario(5);
+    const jsonAst = parse(rawJson, { loc: true });
+    expect(
+      getMetaFromPath(jsonAst, '/foo/~1some~1path/value')
+    ).toMatchSnapshot();
+  });
+
+  it('can work with unescaped JSON pointers with ~0', async () => {
+    const rawJson = await loadScenario(5);
+    const jsonAst = parse(rawJson, { loc: true });
+    expect(
+      getMetaFromPath(jsonAst, '/foo/~0some~0path/value')
+    ).toMatchSnapshot();
+  });
 });

--- a/src/json/get-decorated-data-path.js
+++ b/src/json/get-decorated-data-path.js
@@ -1,6 +1,13 @@
 export default function getDecoratedDataPath(jsonAst, dataPath) {
-  // TODO: Handle json pointer escape notation and better error handling
+  // TODO: Better error handling
   const pointers = dataPath.split('/').slice(1);
+  for (const index in pointers) {
+    pointers[index] = pointers[index]
+      .split('~1')
+      .join('/')
+      .split('~0')
+      .join('~');
+  }
   let decoratedPath = '';
   pointers.reduce((obj, pointer) => {
     switch (obj.type) {

--- a/src/json/get-meta-from-path.js
+++ b/src/json/get-meta-from-path.js
@@ -3,8 +3,15 @@ export default function getMetaFromPath(
   dataPath,
   isIdentifierLocation
 ) {
-  // TODO: Handle json pointer escape notation and better error handling
+  // TODO: Better error handling
   const pointers = dataPath.split('/').slice(1);
+  for (const index in pointers) {
+    pointers[index] = pointers[index]
+      .split('~1')
+      .join('/')
+      .split('~0')
+      .join('~');
+  }
   const lastPointerIndex = pointers.length - 1;
   return pointers.reduce((obj, pointer, idx) => {
     switch (obj.type) {


### PR DESCRIPTION
As per `TODO` comment.

Tested as fixing the issue, ~~but would appreciate help in writing a new testcase or two to prevent regressions.~~

Tests now copied from https://github.com/torifat/better-ajv-errors/pull/1 hope @ifroz doesn't mind. All passing.