### PR TITLE
fix(typings): Correct TypeScript type definition

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,10 +1,5 @@
 import { ErrorObject } from 'ajv';
 
-declare var betterAjvErrors: betterAjvErrors.IBetterAjvErrors;
-
-export = betterAjvErrors;
-export as namespace betterAjvErrors;
-
 declare namespace betterAjvErrors {
   export interface IInputOptions {
     format?: 'cli' | 'js';
@@ -13,17 +8,30 @@ declare namespace betterAjvErrors {
 
   export interface IOutputError {
     start: { line: number; column: number; offset: number };
-    end?: { line: number; column: number; offset: number };
+    end: { line: number; column: number; offset: number } | undefined;
     error: string;
+    dataPath: string;
     suggestion?: string;
   }
-
-  export interface IBetterAjvErrors {
-    (
-      schema: any,
-      data: any,
-      errors?: ErrorObject[] | null,
-      options?: betterAjvErrors.IInputOptions
-    ): betterAjvErrors.IOutputError[] | void;
-  }
 }
+
+declare function betterAjvErrors(
+  schema: any,
+  data: any,
+  errors?: ErrorObject[] | null,
+  options?: betterAjvErrors.IInputOptions & { format?: 'cli' }
+): string;
+declare function betterAjvErrors(
+  schema: any,
+  data: any,
+  errors: ErrorObject[] | null | undefined,
+  options: betterAjvErrors.IInputOptions & { format: 'js' }
+): betterAjvErrors.IOutputError[];
+declare function betterAjvErrors(
+  schema: any,
+  data: any,
+  errors?: ErrorObject[] | null,
+  options?: betterAjvErrors.IInputOptions
+): string | betterAjvErrors.IOutputError[];
+
+export = betterAjvErrors;


### PR DESCRIPTION
The current **TypeScript** type definition is wrong in many aspects.

This fixes all errors with it.