### PR TITLE
:fire_engine: Bump `jsonpointer` - CVE-2021-23807

### DIFF
--- a/.changeset/light-papayas-play/changes.json
+++ b/.changeset/light-papayas-play/changes.json
@@ -1,4 +1,0 @@
-{
-  "releases": [{ "name": "better-ajv-errors", "type": "minor" }],
-  "dependents": []
-}

--- a/.changeset/light-papayas-play/changes.md
+++ b/.changeset/light-papayas-play/changes.md
@@ -1,1 +1,0 @@
-ajv 8 support

--- a/.changeset/popular-guests-confess/changes.json
+++ b/.changeset/popular-guests-confess/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "better-ajv-errors", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/popular-guests-confess/changes.md
+++ b/.changeset/popular-guests-confess/changes.md
@@ -1,0 +1,1 @@
+:fire_engine: Bump `jsonpointer` - CVE-2021-23807

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # better-ajv-errors
 
+## 0.8.0
+
+### Minor Changes
+
+- 8846dda: ajv 8 support
+
 ## 0.7.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-ajv-errors",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "JSON Schema validation for Human",
   "repository": "atlassian/better-ajv-errors",
   "main": "index.js",


### PR DESCRIPTION
Force minimum version to https://github.com/janl/node-jsonpointer/releases/tag/v4.1.0