### PR TITLE
:fire_engine: Bump `jsonpointer` - CVE-2021-23807

### DIFF
--- a/.changeset/thin-carpets-fix/changes.json
+++ b/.changeset/thin-carpets-fix/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "better-ajv-errors", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/thin-carpets-fix/changes.md
+++ b/.changeset/thin-carpets-fix/changes.md
@@ -1,0 +1,1 @@
+:fire_engine: Bump `jsonpointer` - CVE-2021-23807

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chalk": "^2.4.1",
     "core-js": "^3.2.1",
     "json-to-ast": "^2.0.3",
-    "jsonpointer": "^4.0.1",
+    "jsonpointer": "^4.1.0",
     "leven": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,9 +3999,10 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpointer@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+jsonpointer@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.1.0.tgz#501fb89986a2389765ba09e6053299ceb4f2c2cc"
+  integrity sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
Force minimum version to https://github.com/janl/node-jsonpointer/releases/tag/v4.1.0

Fixes #100 