### PR TITLE
:fire_engine: Bump `jsonpointer` to v5 - CVE-2021-23807

### DIFF
--- a/.changeset/lemon-geckos-promise/changes.json
+++ b/.changeset/lemon-geckos-promise/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "better-ajv-errors", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/lemon-geckos-promise/changes.md
+++ b/.changeset/lemon-geckos-promise/changes.md
@@ -1,0 +1,1 @@
+:fire_engine: Bump `jsonpointer` - CVE-2021-23807

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chalk": "^2.4.1",
     "core-js": "^3.2.1",
     "json-to-ast": "^2.0.3",
-    "jsonpointer": "^4.1.0",
+    "jsonpointer": "^5.0.0",
     "leven": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,10 +3999,10 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpointer@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.1.0.tgz#501fb89986a2389765ba09e6053299ceb4f2c2cc"
-  integrity sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==
+jsonpointer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
+  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23807

Closes #100 