### PR TITLE
refactor: use map instead of for/in loop

### DIFF
--- a/.changeset/silent-buckets-compete.md
+++ b/.changeset/silent-buckets-compete.md
@@ -1,0 +1,5 @@
+---
+'better-ajv-errors': patch
+---
+
+Remove for...in loop to prevent possible enumeration errors

--- a/src/json/utils.js
+++ b/src/json/utils.js
@@ -1,12 +1,12 @@
 // TODO: Better error handling
 export const getPointers = dataPath => {
-  const pointers = dataPath.split('/').slice(1);
-  for (const index in pointers) {
-    pointers[index] = pointers[index]
-      .split('~1')
-      .join('/')
-      .split('~0')
-      .join('~');
-  }
-  return pointers;
+  return dataPath
+    .split('/')
+    .slice(1)
+    .map((pointer) =>
+      pointer.split('~1')
+        .join('/')
+        .split('~0')
+        .join('~')
+    );
 };


### PR DESCRIPTION
Using a for...in loop on an array is prone to errors because it loops over all enumerable properties (including functions). If another library adds a function to the Array prototype, then this breaks because it will include that function. This was happening in our case. Another library was modifying the Array prototype and causing errors in this code.

We could fix the problem by replacing the for...in loop with a for...of loop, but map is probably a better solution here since we are modifying every element in the array. I have changed the for...in loop to a map.

[Difference between for...of and for...in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#difference_between_for...of_and_for...in)