### PR TITLE
Fix exports reference to typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./typings.d.ts",
       "require": "./lib/cjs/index.js",
       "default": "./lib/esm/index.mjs"
     }


### PR DESCRIPTION
Recent TypeScript versions don't work without having this "types" property in the exports field.